### PR TITLE
20221116 cicd 一直錯順便發現的

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "php": ">=5.6",
     "guzzlehttp/guzzle": ">6.2",
     "illuminate/support": ">5.0",
-    "opentracing/opentracing": "^1.0.0",
+    "opentracing/opentracing": "1.0.0-beta6",
     "paragonie/random_compat": "^1.4|^2.0|^9.0",
     "psr/cache": "~1.0.1"
   },
@@ -53,7 +53,10 @@
     "jonahgeorge/jaeger-client-php": "dev-feature/php56"
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "kylekatarnls/update-helper": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c9967852b192681ceab1314f0c5d5b3",
+    "content-hash": "9a6be45e1441403d0a9bd9a70a053341",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -874,13 +874,13 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "OpenTracing\\": "src/OpenTracing/"
-                },
                 "files": [
                     "src/OpenTracing/Tags.php",
                     "src/OpenTracing/Formats.php"
-                ]
+                ],
+                "psr-4": {
+                    "OpenTracing\\": "src/OpenTracing/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -893,6 +893,10 @@
                 }
             ],
             "description": "OpenTracing API for PHP",
+            "support": {
+                "issues": "https://github.com/opentracing/opentracing-php/issues",
+                "source": "https://github.com/opentracing/opentracing-php/tree/1.0.0-beta6"
+            },
             "time": "2019-04-10T07:57:39+00:00"
         },
         {
@@ -4741,5 +4745,5 @@
         "php": ">=5.6"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
此repo 相依的 opentracing 在日後的function signature 會定義回傳型態, 為避免日後fbbuy-great-again 有需要下composer update 卻臨時不知道為何會噴以下錯誤, 故補上此固定版號 

![圖片](https://user-images.githubusercontent.com/2196511/202126892-4d5892b2-948b-46e2-a6e2-f1f3801a0b3e.png)
